### PR TITLE
fix: games needed formula

### DIFF
--- a/components/estimate.tsx
+++ b/components/estimate.tsx
@@ -26,8 +26,8 @@ export function Estimate() {
   );
   const { goals, gamesPlayed } = stats.featuredStats.regularSeason.subSeason;
   const goalsPerGame = goals / gamesPlayed;
-  const goalsNeeded = totalGoalsNeededToBreak - goalsToStartTheSeason;
-  const gamesNeeded = Math.ceil(goalsNeeded * goalsPerGame);
+  const goalsNeeded = totalGoalsNeededToBreak - goalsToStartTheSeason - goals;
+  const gamesNeeded = Math.ceil(goalsNeeded / goalsPerGame);
   const nextGameIndex = schedule.games.findIndex(
     (game: { startTimeUTC: string }) => {
       const startUTC = new Date(game.startTimeUTC);


### PR DESCRIPTION
This PR changes the `gamesNeeded` calculation to _divide_ correct amount of goals needed (remaining) by the goals/game ratio.

This resolves https://github.com/itsdouges/is-ovechkin-there-yet/issues/1.